### PR TITLE
Fix error on empty line

### DIFF
--- a/syscall2seccomp.py
+++ b/syscall2seccomp.py
@@ -34,7 +34,10 @@ def main():
 
     with fileinput.input(files=(args.strace)) as f:
         if args.sysdig:
-            app_syscalls.update((x.replace('>','<').split(' < ', 1)[1].split(' ')[0] for x in f))
+            for x in f:
+                x=x.strip()
+                if x:
+                    app_syscalls.update(x.replace('>','<').split(' < ', 1)[1].split(' ')[0])
         else: 
             app_syscalls.update((x.split('(', 1)[0] for x in f if x[0].isalpha()))
     


### PR DESCRIPTION
Fix error on empty line in sysdig result:

Traceback (most recent call last):
  File "syscall2seccomp/syscall2seccomp.py", line 77, in <module>
    main()
  File "syscall2seccomp/syscall2seccomp.py", line 39, in main
    app_syscalls.update(x.replace('>','<').split(' < ', 1)[1].split(' ')[0])
IndexError: list index out of range